### PR TITLE
always use server's locale to parse date

### DIFF
--- a/templatefunc.go
+++ b/templatefunc.go
@@ -352,7 +352,7 @@ func ParseForm(form url.Values, obj interface{}) error {
 				if len(tags) > 1 {
 					format = tags[1]
 				}
-				t, err := time.Parse(format, value)
+				t, err := time.ParseInLocation(format, value, time.Local)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
When parsing the date without time, it's always using UTC date, which is
unexpected. If we want to use UTC date, it's recommend to set the
server's timezone as UTC, and keep the code flexible.
